### PR TITLE
fix: adiciona o evento de clicar no enter do teclado e faz o teclado …

### DIFF
--- a/app/src/main/java/br/com/passwordkeeper/presentation/ui/fragment/SignUpFragment.kt
+++ b/app/src/main/java/br/com/passwordkeeper/presentation/ui/fragment/SignUpFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.widget.ImageButton
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -11,6 +12,7 @@ import br.com.passwordkeeper.R
 import br.com.passwordkeeper.databinding.SignUpFragmentBinding
 import br.com.passwordkeeper.domain.result.viewmodelstate.CreateUserStateResult
 import br.com.passwordkeeper.domain.result.viewmodelstate.FormValidationSignUpStateResult
+import br.com.passwordkeeper.extensions.hideKeyboard
 import br.com.passwordkeeper.extensions.showMessage
 import br.com.passwordkeeper.presentation.ui.viewModel.SignUpViewModel
 import org.koin.android.ext.android.inject
@@ -26,7 +28,7 @@ class SignUpFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View? {
         val binding = SignUpFragmentBinding
             .inflate(
@@ -42,8 +44,18 @@ class SignUpFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         setupBackButton()
         setupCreateAccountButton()
+        setupConfirmedPasswordEditText()
         observeFormValidation()
         observeSignUp()
+    }
+
+    private fun setupConfirmedPasswordEditText() {
+        binding.inputConfirmPassword.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                binding.inputConfirmPassword.hideKeyboard()
+            }
+            true
+        }
     }
 
     private fun setupBackButton() {

--- a/app/src/main/res/layout/sign_up_fragment.xml
+++ b/app/src/main/res/layout/sign_up_fragment.xml
@@ -182,6 +182,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="textPassword"
+            android:imeOptions="actionDone"
             />
     </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
Testei aqui no meu emulador, teve algumas horas que o teclado não sumiu após clicar no entender do keyboard.
Aparentemente, é um bug intermitente, as vezes acontece as vezes não.

Adicionei no código um evento para o campo de ConfirmedPassword para toda vez que o usuário clicar no enter, chamar sua função de esconder o teclado obrigatoriamente. Favor revisar.

A propriedade no layout que adicionei "ime_option" serve para trocar o ícone do enter do teclado. É ali que trocamos para o ícone de lupa, de done, de próximo. Aparentemente, os editText já vem por padrão com o valor "ir pro próximo", mas tava bugando por algum motivo.